### PR TITLE
Fix race condition in json.Register

### DIFF
--- a/json/handler.go
+++ b/json/handler.go
@@ -117,6 +117,12 @@ func Register(registrar tchannel.Registrar, funcs Handlers, onError func(context
 			return tchannel.TracerFromRegistrar(registrar)
 		}
 		handlers[m] = h
+	}
+
+	// We have to register the methods after we've placed all handlers in the map to avoid a data race where one of the
+	// handlers is called, which would cause us to read from the map, potentially while it's still being written to by
+	// the for loop above.
+	for m := range funcs {
 		registrar.Register(handler, m)
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I changed the `json.Register` function to only invoke `registrar.Register` after all handlers have been added to the map.

## Why?
<!-- Tell your future self why have you made these changes -->
It's possible for one of the handlers to be invoked after it has been registered with the registrar. Also, there's nothing stopping that from happening before we've finished writing to the `handlers` map, and the `handler` function reads from that same map, so this could lead to a data race.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/temporal/issues/5123

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
You can see a justification for this here: https://github.com/temporalio/temporal/issues/5123#issuecomment-1813538491.
It's hard to reproduce this in temporal itself because it's a very rare bug, so I'm not going to try. The change itself is small, so it should be easy to see if it goes away.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
No.