### PR TITLE
json: fix data race when registering handlers

### DIFF
--- a/json/handler.go
+++ b/json/handler.go
@@ -117,6 +117,11 @@ func Register(registrar tchannel.Registrar, funcs Handlers, onError func(context
 			return tchannel.TracerFromRegistrar(registrar)
 		}
 		handlers[m] = h
+	}
+
+	// Call Register after handlers map was filled to avoid possible data races,
+	// see [https://github.com/temporalio/temporal/issues/4000].
+	for m := range handlers {
 		registrar.Register(handler, m)
 	}
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
json call handler is registered in given Registar once handlers map was filled. This fixes data race with map access when inbound call arrives in the middle of registration provoking concurrent map read/write, see temporalio/temporal#4000

## Why?
It seems handler registration logic must be thread-safe since ringpop-go will register handlers for tchannel instance that is already listening to incoming requests.

## Checklist
<!--- add/delete as needed --->

1. Closes temporalio/temporal#4000

2. How was this tested:
By running patched temporal server with race detector thousand times

3. Any docs updates needed?
No

